### PR TITLE
Adding more places to look for default lexicon, using site as well as distutils.

### DIFF
--- a/pysentencizer/pysentencizer.py
+++ b/pysentencizer/pysentencizer.py
@@ -20,6 +20,7 @@ import string
 import sys
 import os.path
 import distutils.sysconfig
+import site
 
 PACKAGE="pysentencizer"
 LOCAL="en"
@@ -40,6 +41,14 @@ class BrillLexicon(object):
 
 		packageFileName = str(distutils.sysconfig.get_python_lib())+"/"+PACKAGE+"/"+LOCAL+"/brill-lexicon.dat"
 		localFileName = PACKAGE+"/"+LOCAL+"/brill-lexicon.dat"
+		
+		# allows looking for the package in, eg, /usr/local/lib
+		siteFileNames = []
+		for dir in site.getsitepackages():
+			siteFileName = dir+"/"+PACKAGE+"/"+LOCAL+"/brill-lexicon.dat"
+			if (os.path.isfile(siteFileName)):
+				fileName = siteFileName
+				break				
 
 		if fileName != None:
 			pass


### PR DESCRIPTION
I was able to install pySentencizer successfully for a bot I'm working on, but at runtime it failed to find the default Brill lexicon, since the package was in /usr/local/lib (and distutils only looked in /usr/lib). This change fixes that.
